### PR TITLE
removed the error if an image has not been uploaded to a bar

### DIFF
--- a/app/views/bars/show.html.erb
+++ b/app/views/bars/show.html.erb
@@ -1,7 +1,11 @@
 <h2><%= @bar.name %></h2>
 <p><%= @bar.url %></p>
 <p><%= @bar.telephone %></p>
-<%= cl_image_tag @bar.photo.key, height: 300, width: 400, crop: :fill %>
+<% if @bar.photo.attached? %>
+  <%= cl_image_tag(@bar.photo.key, height: 300, width: 400, crop: :fill) %>
+<% else %>
+  <img src="">
+<% end %>
 
 <br>
 <div class="container">


### PR DESCRIPTION
Now if a bar owner creates a bar without an image, there is no nil class error